### PR TITLE
Fixed a typo in the readme file : 'runspider'>'run_spider'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Example:
     # do stuff with items ...
 
     # Run an existing spider class.
-    items = scrapydo.runspider('http://example.com')
+    items = scrapydo.run_spider('http://example.com')
     # do stuff with items ...
 
 


### PR DESCRIPTION
I found a typo in the readme file while following the instructions to use scrapydo in my project. Just an underscore missing